### PR TITLE
Add evtbackup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,13 +7,9 @@ ifeq ($(strip $(DEVKITPPC)),)
 $(error "Please set DEVKITPPC in your environment. export DEVKITPPC=<path to>devkitPPC")
 endif
 
-ifeq ($(strip $(TTYDTOOLS)),)
-$(error "Please set TTYDTOOLS in your environment. export TTYDTOOLS=<path to>ttyd-tools")
-endif
-
 include $(DEVKITPPC)/wii_rules
 
-export ELF2REL	:=	$(TTYDTOOLS)/bin/elf2rel
+export ELF2REL	:=	pyelf2rel
 
 ifeq ($(VERSION),)
 all: us0 us1 us2 jp0 jp1 eu0 eu1 kr0
@@ -55,9 +51,9 @@ else
 #---------------------------------------------------------------------------------
 TARGET		:=	$(notdir $(CURDIR)).$(VERSION)
 BUILD		:=	build.$(VERSION)
-SOURCES		:=	source $(wildcard source/*)
-DATA		:=	data  
-INCLUDES	:=	include spm-headers/include spm-headers/mod
+SOURCES		:=	source $(wildcard source/*) vendor/EASTL/source $(wildcard vendor/EASTL/source/*)
+DATA		:=	data
+INCLUDES	:=	include spm-headers/include spm-headers/mod vendor/EABase/include/Common vendor/EABase/include/Common vendor/EASTL/include
 
 #---------------------------------------------------------------------------------
 # options for code generation
@@ -65,7 +61,7 @@ INCLUDES	:=	include spm-headers/include spm-headers/mod
 
 MACHDEP		= -mno-sdata -mgcn -DGEKKO -mcpu=750 -meabi -mhard-float
 
-CFLAGS		= -nostdlib -ffunction-sections -fdata-sections -g -O3 -Wall $(MACHDEP) $(INCLUDE)
+CFLAGS		= -nostdlib -ffunction-sections -fdata-sections -g -O3 -Wall $(MACHDEP) $(INCLUDE) -fpermissive -D__powerpc__ -DEA_PLATFORM_LINUX
 CXXFLAGS	= -fno-exceptions -fno-rtti -std=gnu++17 $(CFLAGS)
 
 LDFLAGS		= -r -e _prolog -u _prolog -u _epilog -u _unresolved -Wl,--gc-sections -nostdlib -g $(MACHDEP) -Wl,-Map,$(notdir $@).map
@@ -200,7 +196,7 @@ $(OFILES_SOURCES) : $(HFILES)
 # REL linking
 %.rel: %.elf
 	@echo output ... $(notdir $@)
-	@$(ELF2REL) $< -s $(MAPFILE)
+	$(ELF2REL) $< $(MAPFILE)
 
 #---------------------------------------------------------------------------------
 # This rule links in binary data with the .jpg extension

--- a/include/evtbackup.h
+++ b/include/evtbackup.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <evt_cmd.h>
+#include "stack.hh"
+
+namespace mod::evtbackup {
+  using namespace spm::evtmgr;
+  void backupLocalWork(s32 index, EvtVar value, EvtEntry * evtEntry);
+  EvtVar restoreLocalWork(s32 index, EvtEntry * evtEntry);
+  void destroyStack(s32 index);
+
+  // evt_backupLocalWork(s32 index, EvtVar value)
+  EVT_DECLARE_USER_FUNC(evt_backupLocalWork, 2)
+
+  // evt_restoreLocalWork(s32 index, EvtVar value)
+  EVT_DECLARE_USER_FUNC(evt_restoreLocalWork, 2)
+
+}

--- a/include/evtbackup.h
+++ b/include/evtbackup.h
@@ -9,6 +9,8 @@ namespace mod::evtbackup {
   EvtVar restoreLocalWork(s32 index, EvtEntry * evtEntry);
   void destroyStack(s32 index);
 
+  //note: index is equal to LW value (i.e the index for LW(0) would be zero)
+
   // evt_backupLocalWork(s32 index, EvtVar value)
   EVT_DECLARE_USER_FUNC(evt_backupLocalWork, 2)
 

--- a/include/evtbackup.h
+++ b/include/evtbackup.h
@@ -17,4 +17,10 @@ namespace mod::evtbackup {
   // evt_restoreLocalWork(s32 index, EvtVar value)
   EVT_DECLARE_USER_FUNC(evt_restoreLocalWork, 2)
 
+    // backs up all local work to the stack
+    EVT_DECLARE_USER_FUNC(evt_backupLocalWorkAll, 0)
+
+    // restores all local work from the stack
+    EVT_DECLARE_USER_FUNC(evt_restoreLocalWorkAll, 0)
+
 }

--- a/include/stack.hh
+++ b/include/stack.hh
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <common.h>
+#include <spm/system.h>
+#include <wii/os.h>
 
 namespace mod {
 

--- a/source/evtbackup.cpp
+++ b/source/evtbackup.cpp
@@ -1,0 +1,61 @@
+#include "evtbackup.h"
+#include "evtpatch.h"
+#include <msl/string.h>
+#include <spm/evtmgr_cmd.h>
+#include <spm/memory.h>
+#include <spm/system.h>
+#include <wii/os.h>
+
+namespace mod::evtbackup {
+
+using namespace spm::evtmgr;
+using namespace mod::evtpatch;
+
+static Stack<EvtVar>* localWorkStack[EVT_ENTRY_MAX][16];
+
+void backupLocalWork(s32 index, EvtVar value, EvtEntry * evtEntry) {
+  s32 entryIndex = getEvtEntryIdx(evtEntry);
+  Stack<EvtVar>* stack = localWorkStack[entryIndex][index];
+  if (stack == nullptr) {
+      localWorkStack[entryIndex][index] = new Stack<EvtVar>();
+      stack = localWorkStack[entryIndex][index];
+  }
+  stack->push(spm::evtmgr_cmd::evtGetValue(evtEntry, value));
+}
+
+EvtVar restoreLocalWork(s32 index, EvtEntry * evtEntry) {
+  s32 entryIndex = getEvtEntryIdx(evtEntry);
+  Stack<EvtVar>* stack = localWorkStack[entryIndex][index];
+  EvtVar ret = stack->pop();
+  if (stack->isEmpty()) {
+    stack->clear();
+    delete stack;
+    localWorkStack[entryIndex][index] = nullptr;
+  }
+  return ret;
+}
+
+void destroyStack(s32 index) {
+  for (s32 i = 0; i < 16; i++) {
+      if (localWorkStack[index][i] != nullptr) {
+        Stack<EvtVar>* stack = localWorkStack[index][i];
+        stack->clear();
+        delete stack;
+        localWorkStack[index][i] = nullptr;
+      }
+  }
+}
+
+s32 evt_backupLocalWork(EvtEntry * evtEntry, bool firstRun) {
+  spm::evtmgr::EvtVar * args = (EvtVar * ) evtEntry -> pCurData;
+  backupLocalWork(args[0], args[1], evtEntry);
+  return 2;
+}
+
+s32 evt_restoreLocalWork(EvtEntry * evtEntry, bool firstRun) {
+  spm::evtmgr::EvtVar * args = (EvtVar * ) evtEntry -> pCurData;
+  spm::evtmgr_cmd::evtSetValue(evtEntry, args[0], restoreLocalWork(args[1], evtEntry));
+  return 2;
+}
+
+}

--- a/source/evtbackup.cpp
+++ b/source/evtbackup.cpp
@@ -11,40 +11,66 @@ namespace mod::evtbackup {
 using namespace spm::evtmgr;
 using namespace mod::evtpatch;
 
-static Stack<EvtVar>* localWorkStack[EVT_ENTRY_MAX][16];
+static Stack<Stack<EvtVar>*>* localWorkStack[EVT_ENTRY_MAX];
 
-void backupLocalWork(s32 index, EvtVar value, EvtEntry * evtEntry) {
-  s32 entryIndex = getEvtEntryIdx(evtEntry);
-  Stack<EvtVar>* stack = localWorkStack[entryIndex][index];
-  if (stack == nullptr) {
-      localWorkStack[entryIndex][index] = new Stack<EvtVar>();
-      stack = localWorkStack[entryIndex][index];
-  }
-  stack->push(spm::evtmgr_cmd::evtGetValue(evtEntry, value));
+void backupLocalWork(s32 index, EvtVar value, EvtEntry* evtEntry) {
+    s32 entryIndex = getEvtEntryIdx(evtEntry);
+
+    // Check if a top-level stack exists
+    if (localWorkStack[entryIndex] == nullptr) {
+        localWorkStack[entryIndex] = new Stack<Stack<EvtVar>*>();
+    }
+
+    Stack<Stack<EvtVar>*>* topStack = localWorkStack[entryIndex];
+
+    // Check if a sub-stack exists
+    if (topStack->isEmpty() || topStack->peek() == nullptr) {
+        topStack->push(new Stack<EvtVar>());
+    }
+
+    // Push the value into the top sub-stack
+    Stack<EvtVar>* subStack = topStack->peek();
+    subStack->push(spm::evtmgr_cmd::evtGetValue(evtEntry, value));
 }
 
-EvtVar restoreLocalWork(s32 index, EvtEntry * evtEntry) {
-  s32 entryIndex = getEvtEntryIdx(evtEntry);
-  Stack<EvtVar>* stack = localWorkStack[entryIndex][index];
-  EvtVar ret = stack->pop();
-  if (stack->isEmpty()) {
-    stack->clear();
-    delete stack;
-    localWorkStack[entryIndex][index] = nullptr;
-  }
-  return ret;
+EvtVar restoreLocalWork(s32 index, EvtEntry* evtEntry) {
+    s32 entryIndex = getEvtEntryIdx(evtEntry);
+    Stack<Stack<EvtVar>*>* topStack = localWorkStack[entryIndex];
+
+    Stack<EvtVar>* subStack = topStack->peek();
+
+    EvtVar ret = subStack->pop();
+
+    // If the either stack becomes empty, delete it
+    if (subStack->isEmpty()) {
+        delete subStack;
+        topStack->pop();
+    }
+
+    if (topStack->isEmpty()) {
+        delete topStack;
+        localWorkStack[entryIndex] = nullptr;
+    }
+
+    return ret;
 }
+
 
 void destroyStack(s32 index) {
-  for (s32 i = 0; i < 16; i++) {
-      if (localWorkStack[index][i] != nullptr) {
-        Stack<EvtVar>* stack = localWorkStack[index][i];
-        stack->clear();
-        delete stack;
-        localWorkStack[index][i] = nullptr;
-      }
-  }
+    Stack<Stack<EvtVar>*>* topStack = localWorkStack[index];
+    if (topStack != nullptr) {
+        while (!topStack->isEmpty()) {
+            Stack<EvtVar>* subStack = topStack->pop();
+            if (subStack != nullptr) {
+                subStack->clear();
+                delete subStack;
+            }
+        }
+        delete topStack;
+        localWorkStack[index] = nullptr;
+    }
 }
+
 
 s32 evt_backupLocalWork(EvtEntry * evtEntry, bool firstRun) {
   spm::evtmgr::EvtVar * args = (EvtVar * ) evtEntry -> pCurData;
@@ -52,9 +78,23 @@ s32 evt_backupLocalWork(EvtEntry * evtEntry, bool firstRun) {
   return 2;
 }
 
+s32 evt_backupLocalWorkAll(EvtEntry * evtEntry, bool firstRun) {
+  for (s32 i = 0; i < 16; i++) {
+  backupLocalWork(i, evtEntry->lw[i], evtEntry);
+}
+  return 2;
+}
+
 s32 evt_restoreLocalWork(EvtEntry * evtEntry, bool firstRun) {
   spm::evtmgr::EvtVar * args = (EvtVar * ) evtEntry -> pCurData;
   spm::evtmgr_cmd::evtSetValue(evtEntry, args[0], restoreLocalWork(args[1], evtEntry));
+  return 2;
+}
+
+s32 evt_restoreLocalWorkAll(EvtEntry * evtEntry, bool firstRun) {
+  for (s32 i = 0; i < 16; i++) {
+  spm::evtmgr_cmd::evtSetValue(evtEntry, evtEntry->lw[i], restoreLocalWork(i, evtEntry));
+}
   return 2;
 }
 

--- a/source/evtpatch.cpp
+++ b/source/evtpatch.cpp
@@ -1,5 +1,6 @@
 #include "evtpatch.h"
 #include "evtopcodes.h"
+#include "evtbackup.h"
 #include "patch.h"
 #include <msl/string.h>
 #include <spm/evtmgr_cmd.h>
@@ -10,6 +11,7 @@
 namespace mod::evtpatch {
 
 using namespace spm::evtmgr;
+using namespace mod::evtbackup;
 
 static Stack<EvtScriptCode*>* returnStacks[EVT_ENTRY_MAX];
 
@@ -138,6 +140,7 @@ static void (*evtmgrReInitReal)();
 static void evtmgrReInitPatch() {
     evtmgrReInitReal = patch::hookFunction(spm::evtmgr::evtmgrReInit, []() {
         for (s32 i = 0; i < EVT_ENTRY_MAX; i++) {
+            destroyStack(i);
             if (returnStacks[i] != nullptr) {
                 evtmgrDestroyReturnStack(i);
             }

--- a/source/mod.cpp
+++ b/source/mod.cpp
@@ -2,6 +2,7 @@
 #include "cutscene_helpers.h"
 #include "evt_cmd.h"
 #include "evtpatch.h"
+#include "evtbackup.h"
 #include "exception.h"
 #include "patch.h"
 #include "romfontexpand.h"
@@ -225,6 +226,9 @@ EVT_BEGIN(funnyCutscene)
     USER_FUNC(spm::evt_npc::evt_npc_set_anim, PTR("enma"), 0, 1) // Idle
     USER_FUNC(spm::evt_msg::evt_msg_print, EVT_MSG_FLAG_DIRECT, PTR("<p>Luvbi, you're coming with me.<k>"), 0, PTR("enma"))
     RUN_EVT_ID(luvbiAsyncWalking, LW(0))
+    USER_FUNC(evtbackup::evt_backupLocalWork, 0, LW(0))
+    SET(LW(0), 5)
+    USER_FUNC(evtbackup::evt_restoreLocalWork, LW(0), 0)
     USER_FUNC(spm::evt_npc::evt_npc_set_anim, PTR("enma"), 1, 1) // Walking
     USER_FUNC(spm::evt_npc::evt_npc_walk_to, PTR("enma"), 1100, 0, 0, FLOAT(80.0), 1, 0, 0)
     USER_FUNC(spm::evt_npc::evt_npc_set_anim, PTR("enma"), 0, 1) // Idle


### PR DESCRIPTION
## Evtbackup framework which allows for the backing up of LW slots in evt scripts via a stack based system
### New features:
* evt_backupLocalWork, backs up a local work to the evt stack
* evt_restoreLocalWork, restores a local work from the stack
* destroyStack, added to the evtmgrReInitPatch to prevent memory leaks
* bug fix with stack.hh where it didnt have access to the assert library
* makefile now uses seeky's pyelf2rel for better platform compatibility
* demonstration in lines 229-231 of mod.cpp